### PR TITLE
http collector: don't close body if request wasn't successful

### DIFF
--- a/collector/http.go
+++ b/collector/http.go
@@ -65,10 +65,11 @@ func (p *HTTPExporter) Collect(ch chan<- prometheus.Metric) {
 
 			t := time.Now()
 			res, err := p.client.Get(url)
-			defer res.Body.Close()
 			if err != nil {
 				log.Errorln(err)
 				s = 0
+			} else {
+				defer res.Body.Close()
 			}
 			d := time.Since(t)
 


### PR DESCRIPTION
The old behaviour caused a panic if the request failed. This PR resolves the problem.

```
INFO[0000] Listening on :9449                            source=main.go:79
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x4d941c]

goroutine 10860 [running]:
panic(0x6c6620, 0xc420010130)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/0x46616c6b/connectivity_exporter/collector.(*HTTPExporter).Collect.func1(0xc42045a970, 0xc4200da3a0, 0x7fffffffed9e, 0xe, 0xc42052f140)
        /root/gopath/src/github.com/0x46616c6b/connectivity_exporter/collector/http.go:68 +0xfc
created by github.com/0x46616c6b/connectivity_exporter/collector.(*HTTPExporter).Collect
        /root/gopath/src/github.com/0x46616c6b/connectivity_exporter/collector/http.go:82 +0xe0
```
